### PR TITLE
Proper npm scripts, shorter README and up-to-date documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,129 +1,51 @@
 # Paradone #
 
-Paradone is an Open-Source, peer-to-peer powered overlay network for
-media diffusion in the browser. Its aim is to reduce bandwidth cost of
-media file diffusion for the server and ISPs while providing a better
-service quality to the end user.
+Paradone is an Open-Source, peer-to-peer powered overlay network for media
+diffusion in the browser. Its aim is to reduce bandwidth cost of media file
+diffusion for the server and ISPs while providing a better service quality to
+the end user.
 
-- It uses a mesh overlay network to share media directly between the
-  users
-- It uses the new WebRTC API to provide full P2P capabilities directly
-  inside the web browser
+- It uses a mesh overlay network to share media directly between the users
+- It uses the new WebRTC API to provide full P2P capabilities directly inside
+  the web browser
 - It uses the new Media Source Extension API to play video with HTML5
-- It's a full JavaScript solution which needs no plugin and is
-  invisible to end users
+- It's a full JavaScript solution which needs no plugin and is invisible to end
+  users
 - It's Open-Source and free to use, share and modify
 
-The project was created for and is laureate of the Boost Your Code
-2014 contest.
+The project was created for and is laureate of the Boost Your Code 2014 contest.
 
-The documentation of the project is available on
-[the wiki](https://github.com/GaspardP/Paradone/wiki/)
+Get more information about the project on:
+- [the website](https://paradone.github.io/)
+- [the wiki](https://github.com/Paradone/Paradone/wiki/)
+- [the mailing list](https://sympa.inria.fr/sympa/info/paradone)
+- [the issue tracker](https://github.com/Paradone/Paradone/issues)
 
-The license of the project is available in [the LICENSE file](LICENSE)
+## License ##
 
-## Table of content
-
-* [**Project Details**](#project-details)
-  * [Why](#why)
-  * [How it works](#how-it-works)
-  * [Challenges](#challenges)
-  * [License](#license)
-* [**Getting Started**](#getting-started)
-  * [Requirements](#requirements)
-  * [Installation](#installation)
-* [**Community**](#community)
-  * [Wiki](#wiki)
-  * [Mailing List](#mailing-list)
-  * [Issue tracker](#issue-tracker)
-
-
-## Project Details
-
-### Why
-
-Did you ever tried to see a video but had to wait every 3 seconds to
-wait for it to load? I had this problem, a lot. That's why, seeing how
-new API of HTML5 allow users to share information directly between
-themselves, I decided to build a system using a
-[Mesh overlay](https://en.wikipedia.org/wiki/Mesh_networking) allowing
-media diffusion directly between users. This way the bandwidth's costs
-for the server will decrease and users will be able to retrieve the
-files faster.
-
-### How it works
-
-Paradone uses WebRTC API to create a mesh overlay between the
-users. The first user will download the media directly from the
-server. When a new user request the same media, the server will tell
-him how to connect to the mesh where the file can be retrieved. The
-new user will then download parts of the file from different users
-and/or the server. Finally the parts are glued back together and
-played with the MediaSource API and a HTML5 Video tag.
-
-For a more technical description you can check the
-[Communication Protocol](https://github.com/GaspardP/Paradone/wiki/Documentation-%E2%80%94-Communication-Protocol)
-available on the wiki.
-
-### Challenges  ###
-
-- P2P does not mean “Pirate 2 Pirate”: P2P is often seen as a medium
-  for illegal file sharing but it's not. The main goal of P2P is to
-  allow decentralized communication between users. Decentralization
-  means no more single point of failure (SPOF). In traditional
-  client-server architecture, the server can handle a limited amount
-  of users before failing. With a P2P solution, more users mean a
-  better service.
-- An evolving technology: The W3C specifications for both WebRTC and
-  MSE are not finished yet. It means that the project will have to be
-  modified when the final standards will be published.
-- Web browser interoperation: As the standards are not published in
-  final state yet, different browsers might implement different
-  functionalities leading to difficulties in interoperation.
-
-### License ###
-
-Paradone is licensed under the Affero General Public License version 3
-or later. See the [LICENSE](LICENSE) file for more information.
+Paradone is licensed under the AGPLv3. See the [LICENSE](LICENSE) file for more
+information.
 
 ## Getting Started ##
 
-### Requirements ###
+### Install ###
 
-#### User side ####
+You can either download one of
+[the releases](https://github.com/Paradone/Paradone/releases) or clone the
+project and build the script from source with git and npm.
 
-The user will need an up-to-date web browser supporting both WebRTC
-and Media Source Extension. It can either be Firefox, Google Chrome
-(or Chromium) or Opera.
+```bash
+# Get the project
+git clone https://github.com/Paradone/Paradone.git
+cd Paradone
+# Install dependencies
+npm install
+# Build the script
+npm run build
+```
 
-The video served to the client must be played within a HTML5 Video
-tag. You will need to check the codec of your file
-
-#### Server side ####
-
-The system needs a signaling server allowing users to initiate the
-communication between them. WebRTC lets you choose your preferred
-technology for signaling (websocket, xhr, email...).
-
-- The mesh tracker allows new users to connect to the mesh and act as
-  an entry point
-- The media delivery server is your system used to serve video to the
-  user
-
-#### Developer side ####
-
-The project is written in JavaScript and uses [npm](https://npmjs.com)
-to manage all dependencies.
-
-### Installation ###
-
-Every functions of the project are referenced under the `paradone`
-namespace. You can start using the project by adding the script to
-your page and using the `start` function. The script will find the
-video tags and start sharing it between your users. You can pass
-options as argument to the function, see
-[the documentation](https://github.com/GaspardP/Paradone/wiki/Documentation) for
-more information.
+Copy the file `./dist/paradone.js` in your project directory and add it to your
+website.
 
 ```html
 <script src="./some/path/to/paradone.js"></script>
@@ -132,35 +54,44 @@ more information.
 </script>
 ```
 
-## Community ##
+### Requirements ###
 
-### Contribute ###
+#### User side ####
 
-There are multiple ways you can be part of the project. You can:
-- Use it and fill an issue when you find a bug
-- Fork it, modify it and propose a pull request
-- Add documentation to the wiki
-- Talk about it around you
-- Share your ideas in our tracker
+The user will need an up-to-date web browser supporting both WebRTC and Media
+Source Extension. It can either be Firefox, Google Chrome (or Chromium) or
+Opera.
 
-### Wiki ###
+The video served to the client must be played within a HTML5 Video tag. You will
+need to check the codec of your files.
 
-The wiki contains all information you need to know about the project
-(architecture and implementation details, API…) for more information…
-see [the wiki](https://github.com/GaspardP/Paradone/wiki/)
+Firefox users need to turn the porperty `media.mediasource.webm.enabled` to
+`true` in `about:config`
 
-### Mailing List ###
+#### Server side ####
 
-You can [subcribe](https://sympa.inria.fr/sympa/subscribe/paradone) to
-our [mailing list](https://sympa.inria.fr/sympa/info/paradone) to get
-in touch with the team.
+The system needs a signaling server allowing users to initiate the communication
+between them. WebRTC lets you choose your preferred technology for signaling
+(websocket, xhr, email...).
 
-### Issue tracker ###
+For now the project uses [Firebase](https://www.firebase.com) as [signaling
+server](https://github.com/Paradone/Paradone/wiki/Signal).
 
-All [the issues](https://github.com/GaspardP/Paradone/issues) are
-tracked on Github.
+#### Developer side ####
 
-### Documentation ###
+The project is written in JavaScript and uses [npm](https://npmjs.com) to manage
+all dependencies.
 
-The full documentation is available on the
-[wiki](https://github.com/GaspardP/Paradone/wiki/Documentation).
+Different scripts are available with `npm run`
+- `build` Concatenate and minify the script
+- `debug` Auto-build on save with source-map
+- `test` Run the tests on the source files
+- `watch` Run tests on file change
+
+### Usage ###
+
+Every element of the project is referenced under the `paradone` namespace. Once
+the `start` function called the script will find the video tags and share the
+media between users through the mesh. You can pass options as arguments to the
+`start` function, see the [API](https://github.com/Paradone/Paradone/wiki/API)
+for more detailed informations.

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,9 +1,10 @@
 /* global __dirname */
 'use strict';
 var gulp = require('gulp')
+var uglify = require('gulp-uglify')
 var browserify = require('browserify')
 var karma = require('karma')
-var kbg = require('karma-background')
+var buffer = require('vinyl-buffer')
 var source = require('vinyl-source-stream')
 var watchify = require('watchify')
 
@@ -14,8 +15,13 @@ var destFile = 'paradone.js'
 // var dest = destPath + destFile
 var karmaConf = __dirname + '/karma.conf.js'
 
-gulp.task('default', ['test-watch'], function() {
-  return gulp.src('')
+gulp.task('default', function() {
+  console.info('usage: npm run <command>\n' +
+               '       gulp <command>\n\n' +
+               '  build   Concatenate and minify the script\n' +
+               '  debug   Auto-build on save with source-map\n' +
+               '  test    Run the tests on the source files\n' +
+               '  watch   Run tests on file change\n')
 })
 
 gulp.task('build', function() {
@@ -26,10 +32,12 @@ gulp.task('build', function() {
     baseDir: sources
   }).bundle()
     .pipe(source(destFile))
+    .pipe(buffer())
+    .pipe(uglify())
     .pipe(gulp.dest(destPath))
 })
 
-gulp.task('watch', function() {
+gulp.task('debug', function() {
   var opts = watchify.args
   opts.fullPaths = false
   opts.baseDir = sources
@@ -47,27 +55,22 @@ gulp.task('watch', function() {
 })
 
 /**
- * Initiate
+ * Run the test once the existing Karma server
  */
 gulp.task('test', function(done) {
   karma.server.start({
-    port: 9876,
-    configFile: karmaConf
+    configFile: karmaConf,
+    port: 9877,
+    autoWatch: false,
+    singleRun: true
   }, done)
 })
 
 /**
- * Start Karma Server in background. We need to get the prompt back if we want
- * to finish the task. kbg creates a sub child process before starting the
- * server
+ * Watch source files and test modifications on file save.
  */
-gulp.task('karma-start', function() {
-  kbg({ configFile: karmaConf })
-})
-
-/**
- * Run the test on the existing Karma server
- */
-gulp.task('karma-run', function(done) {
-  karma.runner.run({ port: 9876 }, done)
+gulp.task('watch', function(done) {
+  karma.server.start({
+    configFile: karmaConf
+  }, done)
 })

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -47,11 +47,15 @@ module.exports = function(config) {
 
     // enable / disable watching file and executing tests whenever any file
     // changes
-    autoWatch: true, //true,
+    autoWatch: true,
+
+    // Tells Karma how long to wait (in milliseconds) after any changes have
+    // occurred before starting the test process again.
+    autoWatchBatchDelay: 1000,
 
     // start these browsers. available browser launchers:
     // https://npmjs.org/browse/keyword/karma-launcher
-    browsers: ['ChromeCanary', 'FirefoxDeveloperEdition'],
+    browsers: ['ChromeCanary'],
 
     // Continuous Integration mode
     // if true, Karma captures browsers, runs the tests and exits

--- a/package.json
+++ b/package.json
@@ -7,8 +7,10 @@
   "main": "src/main.js",
   "scripts": {
     "build": "./node_modules/.bin/gulp build",
-    "test": "./node_modules/.bin/gulp test",
     "clean": "find . -type f -name \"#*#\" -o -name \"*~\" -delete;",
+    "debug": "./node_modules/.bin/gulp debug",
+    "doc": "./node_modules/.bin/jsdoc -P ./package.json -d ./doc src/*.js",
+    "test": "./node_modules/.bin/gulp test",
     "watch": "./node_modules/.bin/gulp watch"
   },
   "dependencies": {
@@ -21,17 +23,19 @@
     "gulp": "^3.8.10",
     "gulp-concat": "^2.4.2",
     "gulp-strip-line": "0.0.1",
+    "gulp-uglify": "^1.1.0",
+    "jsdoc": "^3.3.0-beta1",
     "karma": "^0.12.24",
-    "karma-background": "0.0.1",
     "karma-browserify": "^3.0.1",
     "karma-chai": "^0.1.0",
     "karma-chrome-launcher": "^0.1.5",
     "karma-coverage": "^0.2.6",
-    "karma-firefox-launcher": "^0.1.3",
+    "karma-firefox-launcher": "^0.1.4",
     "karma-mocha": "^0.1.9",
     "karma-mocha-reporter": "^0.3.1",
     "karma-notify-reporter": "^0.1.1",
     "karma-sinon": "^1.0.3",
+    "vinyl-buffer": "^1.0.0",
     "vinyl-source-stream": "^1.0.0",
     "watchify": "^2.1.1"
   }

--- a/src/dataChannel.js
+++ b/src/dataChannel.js
@@ -1,6 +1,10 @@
 /* @flow weak */
 'use strict';
 
+/**
+ * Wrapper setting handlers of a RTCDatachannel from a given PeerConnection
+ * @module
+ */
 module.exports = {
   options: {
     optional: [
@@ -14,9 +18,11 @@ module.exports = {
    * callbacks needed to forward events to the Peer and PeerConnection objects
    * (like a connection/disconnection, error and reception of messages)
    *
-   * @param peer {Peer} instance of Peer object the events must be forwarded to
-   * @param peerConnection {PeerConnection} instance of the PeerConnection where
-   * the DataChannel will be stored @param id Id of the remote peer
+   * @param {Peer} peer - Events will be forwarded to this Peer
+   * @param {PeerConnection} peerConnection - PeerConnection where the
+   *                                          DataChannel will be stored
+   * @param {string} id - Id of the remote peer
+   *
    * @return DataChannel
    */
   create: function(peer, peerConnection, remotePeer) {
@@ -28,11 +34,11 @@ module.exports = {
   /**
    * Set all the callbacks of a newly created DataChannel
    *
-   * @param channel {RTCDataChannel} Channel to be configured
-   * @param peer {Peer} instance of Peer object the events must be forwarded to
-   * @param peerConnection {PeerConnection} instance of the PeerConnection where
-   * the DataChannel will be stored
-   * @param id {string} Id of the remote peer
+   * @param {RTCDataChannel} channel - Channel to be configured
+   * @param {Peer} peer - Events must be forwarded to this Peer
+   * @param {PeerConnection} peerConnection - PeerConnection where the
+   *                                          DataChannel will be stored
+   * @param {string} id - Id of the remote peer
    * @return DataChannel
    */
   setHandlers: function(channel, peer, peerConnection, remotePeer) {
@@ -49,9 +55,8 @@ module.exports = {
    * onmessage handler. This allows us to handle data recevied through both the
    * signaling system and the mesh network with the same functions
    *
-   * @param peer {Peer} Instance of the Peer object the message must be
-   * forwarded to
-   * @param event {Event} Contains the message sent by the remote peer
+   * @param {Peer} peer - Messages will be forwarded to this Peer
+   * @param {Event} event - Contains the message sent by the remote peer
    */
   onmessage: function(peer, event) {
     var message = JSON.parse(event.data)

--- a/src/main.js
+++ b/src/main.js
@@ -7,9 +7,9 @@ var PeerConnection = require('./peerConnection.js')
 var Signal = require('./signal.js')
 
 /**
+ * Find every video tag and start downloading and sharing them through the mesh
  *
- *
- * @param config {config}
+ * @param {Object} opts
  *   1. Signaling server
  *   2. Turn/Stun server
  */
@@ -24,6 +24,9 @@ var start = function(opts) {
 
 /**
  * Finds all video tag and try to find the source file on the mesh
+ *
+ * @param {Object} opts
+ * @param {HTMLMediaElement} videoTag
  */
 var parseVideoTag = function(opts, videoTag) {
   var source = videoTag.src
@@ -39,7 +42,39 @@ module.exports = {
   Peer: Peer,
   PeerConnection: PeerConnection,
   Signal: Signal,
-  start: start
+  start: start,
+  util: require('./util.js'),
+  datachannel: require('./dataChannel.js')
 }
-// Global namespace
+
+// Global namespace export
 window.paradone = module.exports
+
+// Additional type definitions
+/**
+ * @typedef {Object} Info
+ * @property {string} url - URL of the media
+ * @property {number} parts - Number of parts for the whole media
+ * @property {number} size - Size of the file
+ * @property {Array.<number>} available - Numbers of parts locally possessed
+ * @property {Remote} remote - Availability of parts on known peers
+ */
+
+/**
+ * @typedef {Object} Message
+ * @property {string} type - message type
+ * @property {string} from - id of the sender
+ * @property {string} to - id of the recipient (-1 for broadcast)
+ * @property {number} ttl - "time to live", maximum number of forwarding
+ * @property {Object} data - Data of the message
+ * @property {Array.<string>} forwardBy - Id of peers which already have
+ *                                        forwarded the message
+ * @property {string} url - URL of the desired media
+ * @property {number} [number] - Number of the part transmitted in
+ *                               `request-part` and `part` messages
+ */
+
+/**
+ * @typedef {Object.<string, Array.<number>>} Remote
+ * Map a peer ID to an array of possessed parts number
+ */

--- a/src/signal.js
+++ b/src/signal.js
@@ -5,10 +5,11 @@ var Firebase = require('firebase')
 module.exports = Signal
 
 /**
- * Connection to the signal server
- * Should ask for an id
+ * @class Connection to the signal server with the Firebase module
+ *
  * @constructor
- * @param peer {Peer}
+ * @param {Peer} peer - Messages will be forwarded to this peer
+ * @param {Object} opts - Connection options for Firebase (url, credentials)
  */
 function Signal(peer, opts) {
   this.id = String(Date.now()) + String(Math.random()).slice(1, 6)
@@ -23,13 +24,20 @@ function Signal(peer, opts) {
 }
 
 /**
+ * @return {string} Id of the peer
+ */
+Signal.prototype.getId = function() {
+  return this.id
+}
+
+/**
  * Use the signal server to transmit a message.
  * Two modification need to be done to the message:
  * - The ttl will be set to 0 to prevent forwarding redundancy after the
  *   Firebase broadcast
  * - The message data will be transformed to a JSON String
  *
- * @param message {Message} message to be sent on the mesh
+ * @param {Message} message -  message to be sent on the mesh
  */
 Signal.prototype.send = function(message) {
   message.ttl = 0
@@ -40,9 +48,10 @@ Signal.prototype.send = function(message) {
 /**
  * Defines the callback handling new messages received from the sigbal server
  *
- * @param firebase {Firebase}
- * @param id {string} Id of the peer
- * @param peer {Peer} instance of Peer object messages should be sent to
+ * @private
+ * @param {Firebase} firebase
+ * @param {string} id -  Id of the peer
+ * @param {Peer} peer -  instance of Peer object messages should be sent to
  */
 var setOnMessage = function(firebase, id, peer) {
   firebase.on('child_added', function(snapshot) {
@@ -58,11 +67,4 @@ var setOnMessage = function(firebase, id, peer) {
       peer.emit(message.type, message)
     }
   })
-}
-
-/**
- * @return {string} Id of the peer
- */
-Signal.prototype.getId = function() {
-  return this.id
 }

--- a/src/util.js
+++ b/src/util.js
@@ -3,7 +3,7 @@
 module.exports = {
   /**
    * Special wrapping for promise related errors with line number
-   * @param e {Error} contains detailed information on the error
+   * @param {Error} e - Contains detailed information on the error
    */
   error: function(e) {
     return function(err) {
@@ -37,6 +37,8 @@ module.exports = {
 
   /**
    * Shuffle an array
+   * @param {Array} array
+   * @param {Array} Same array xith its elements shuffled
    */
   shuffleArray: function(array) {
     var i, j, temp


### PR DESCRIPTION
Use `npm run <task>` to run gulp task when gulp is not installed globally. Possible tasks are: build, clean, debug, doc, test and watch.
Full documentation should be available for all files and one can use jsdoc to generate a HTML output.