### PR TITLE
[#7] `connected` event was triggered twice

### DIFF
--- a/src/peerConnection.js
+++ b/src/peerConnection.js
@@ -159,7 +159,6 @@ function PeerConnection(peer, remotePeer) {
       peer,
       pc,
       remotePeer)
-    peer.emit('connected', remotePeer)
   }
 
   // Supercharged RTCPeerConnection


### PR DESCRIPTION
Fix #7, now connected/disconnected states reflect the state of the DataChannel